### PR TITLE
Don't include starting space chars into rootname

### DIFF
--- a/src/rhoplot@proc.f90
+++ b/src/rhoplot@proc.f90
@@ -1216,7 +1216,12 @@ contains
        ok = (len_trim(word)>0)  .and. lp.le.ll
 
        if (equal(word,'files').or.equal(word,'root').or.equal(word,'oname')) then
-          rootname = line(lp:)
+          ! skip spaces
+          i=lp
+          do while (line(i:i)==" ")
+             i=i+1
+          enddo
+          rootname = line(i:)
           datafile = trim(rootname) // ".dat" 
 
        else if (equal(word,'plane')) then


### PR DESCRIPTION
hello

when there are >1 space chars between "root" and "<rootname.s>" (in a
grdvec/endgrdvec scope), the additional space chars end up into the
rootname string. Eg:

    ----8<----
    [...]
    grdvec
     root     003_grdvec_crys-gen
     #    ^^^^  these space chars
     plane 0 0 0 1 0 0 0 1 0
     scale 1.1 1.1
     outcp 1.1 1.1
     bcpall
     contour f 11 11 log 11
    end
    [...]
    ---->8----

The consequence is that the created files have funny names:

    ----8<----
    #:169> ls -1
    '    003_grdvec_crys-gen-label.gnu'
    '    003_grdvec_crys-gen.dat'
    '    003_grdvec_crys-gen.gnu'
    '    003_grdvec_crys-gen.iso'
    '    003_grdvec_crys-gen.neg.iso'
    ./
    ../
    003_grdvec_crys.cri
    003_grdvec_crys.cro
    ---->8----

Here is a fix for that

thanks
ciao
-gabriele
