### PR TITLE
Add HIRSHFELD_I (iterative Hirshfeld) keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ can be used to:
 * Apply chemical bonding analysis tools: non-covalent interaction
   (NCI) plots, ELF plots, and others.
 
+* Partition the electron density into atomic populations and volumes
+  using Hirshfeld and iterative Hirshfeld (Hirshfeld-I,
+  `HIRSHFELD_I`); see [`doc/HIRSHFELD_I.md`](doc/HIRSHFELD_I.md).
+
 Critic2 provides an abstraction layer on top of the underlying quantum
 chemical calculation because it interfaces with many electronic
 structure programs: WIEN2k, elk, PI, Quantum ESPRESSO, abinit, VASP,

--- a/dat/helpdoc/hirshfeld_i.keyw
+++ b/dat/helpdoc/hirshfeld_i.keyw
@@ -1,0 +1,2 @@
+HIRSHFELD_I [WCUBE] [ONLY iat1.i iat2.i ...]
+            [WFCDIR dir.s] [HITOL tol.r] [HIMAXIT maxit.i]

--- a/doc/HIRSHFELD_I.md
+++ b/doc/HIRSHFELD_I.md
@@ -172,8 +172,13 @@ amplification over plain Hirshfeld.
   - `read_db` no longer rejects `q < 0`.
   - New public wrapper `grid1_read_file(g, file, z, q)` so a caller
     can load a `.wfc` from an absolute path (used by `WFCDIR`).
-* `src/types.f90` — `basindat` gained `hi_wfcdir`, `hi_tol`,
-  `hi_maxit`.
+* `src/types.f90` — `basindat` gained the input fields `hi_wfcdir`,
+  `hi_tol`, `hi_maxit` and the per-integration SCF state
+  `hi_isactive`, `hi_qlo`, `hi_qhi`, `hi_frac`, `hi_qfinal`. The state
+  lives on `bas` (mirroring how YT keeps `bas%luw`); only the shared
+  `(Z, q) → grid1` memoisation cache is module-level in
+  `hirshfeld@proc.f90`, where it can stay warm across multiple
+  HIRSHFELD_I invocations like the neutral `agrid` table.
 * `dat/helpdoc/hirshfeld_i.keyw` — keyword syntax shown by the GUI
   help.
 

--- a/doc/HIRSHFELD_I.md
+++ b/doc/HIRSHFELD_I.md
@@ -1,0 +1,195 @@
+# Iterative Hirshfeld (`HIRSHFELD_I`)
+
+`HIRSHFELD_I` performs an iterative Hirshfeld (Hirshfeld-I) partitioning
+of the reference field on a grid, following Bultinck, Van Alsenoy,
+Ayers and Carbó-Dorca, *J. Chem. Phys.* **126**, 144111 (2007)
+([10.1063/1.2715563](https://doi.org/10.1063/1.2715563)).
+
+The motivation is well known: stockholder Hirshfeld weights built from
+neutral free-atom densities systematically underestimate chemical
+polarity, because they do not adapt to the actual charge state of the
+atom in the molecule. Hirshfeld-I cures this by making the
+reference density of each atom *self-consistent* with the population
+it ends up carrying.
+
+## Syntax
+
+```
+HIRSHFELD_I [WCUBE] [ONLY iat1.i iat2.i ...]
+            [WFCDIR dir.s] [HITOL tol.r] [HIMAXIT maxit.i]
+```
+
+| Option         | Default | Meaning                                                                                                     |
+| -------------- | ------- | ----------------------------------------------------------------------------------------------------------- |
+| `WCUBE`        | off     | Write per-atom weight cubes (same as `HIRSHFELD`).                                                          |
+| `ONLY i1 i2…`  | all     | Restrict atomic-property integration to the listed cell atoms.                                              |
+| `WFCDIR dir`   | unset   | Look in `dir` for user-supplied charged `.wfc` files named `<elem>_q+N.wfc` / `<elem>_q-N.wfc`. See below.  |
+| `HITOL tol`    | `1e-4`  | Convergence threshold on `max|ΔQ|` between successive SCF iterations.                                       |
+| `HIMAXIT n`    | `60`    | Maximum number of SCF iterations.                                                                           |
+
+The keyword is otherwise a drop-in replacement for `HIRSHFELD`: it
+needs a grid-type reference field, integrates the same scalar
+properties through `INTEGRABLE`, and reports the same volumes /
+populations / Hirshfeld overlap populations.
+
+## Algorithm
+
+Let `ρ(r)` be the reference (molecular) electron density and let
+`ρ_A^{q}(r)` be the spherically averaged density of atom *A* in
+integer charge state *q*. The Hirshfeld-I weights are
+
+```
+            ρ_A^{q_A}(r)
+w_A(r) = ───────────────────
+          Σ_B ρ_B^{q_B}(r)
+```
+
+where each `q_A` is itself a function of the population that *A* picks
+up under those weights:
+
+```
+N_A = ∫ w_A(r) ρ(r) dr        Q_A = Z_A − N_A
+```
+
+The reference density for a fractional `Q_A` is interpolated linearly
+between the two flanking integer-charge densities,
+
+```
+ρ_A^ref(r) = (1−f) ρ_A^{⌊Q_A⌋}(r) + f ρ_A^{⌈Q_A⌉}(r)        f = Q_A − ⌊Q_A⌋
+```
+
+SCF loop:
+
+1. Initialise every `Q_A = 0` (neutral references).
+2. Pre-load the radial densities for every `(Z, q)` pair currently in
+   use (see the resolution order below). This step is serial so that
+   the next step can be embarrassingly parallel.
+3. In a single OpenMP grid sweep, simultaneously rebuild `Σ_B ρ_B^ref`
+   at every grid point and accumulate `N_A = ∫ w_A ρ dV`.
+4. Update each `Q_A`, derive the bracketing `(⌊Q⌋, ⌈Q⌉)` and the
+   mixing fraction `f`.
+5. If `max|ΔQ|` < `HITOL` exit, else go to step 2.
+
+The same iteration data structure is then handed to
+`intgrid_hirshfeld_fields` and `intgrid_hirshfeld_overlap`, which use
+the converged `ρ_A^ref` (instead of the neutral free-atom density)
+wherever they previously called `agrid(z)%interp`.
+
+## Charged atomic densities
+
+Critic2's built-in `.wfc` tables only contain neutral atoms. Hirshfeld-I
+needs both anionic and cationic references. They are resolved in this
+order, per `(Z, q)`:
+
+1. **User-supplied file (`WFCDIR`).** If `WFCDIR <dir>` is given, the
+   code looks for
+   - `<dir>/<elem>_q+N.wfc` for `q > 0`
+   - `<dir>/<elem>_q-N.wfc` for `q < 0`
+
+   where `<elem>` is the lower-case element symbol. The file format is
+   the standard critic2 `.wfc` (LD1/QE Slater-orbital export). This is
+   the rigorous route — drop in publication-quality charged densities
+   when you have them.
+
+2. **Built-in cation table.** For `q > 0` the existing `read_db` path
+   produces a cation by zeroing trailing orbital occupations.
+
+3. **Anion extrapolation.** For `q < 0`, `read_critic` has been
+   extended: when the requested electron count exceeds the neutral
+   orbital occupations, electrons are added to the highest-occupied
+   orbital up to its angular-momentum capacity `2(2L+1)`. If the
+   capacity is insufficient (which only happens for closed-shell
+   anions beyond the orbitals stored in the standard `.wfc`), the
+   routine emits a warning and uses the best-effort density it
+   managed to build.
+
+4. **Fall back to neutral** if all of the above fail, with a warning.
+
+Iteration `Q_A` is clamped to the half-open interval `[-5, Z)`. The
+upper limit `Q = Z` corresponds to a fully stripped atom (zero density
+everywhere), which is correctly handled by the radial interpolator
+returning zero.
+
+## Worked example — water
+
+Single-point B3LYP/6-31G(d) on H₂O, density cube generated with
+`cubegen 4 fdensity=scf h2o.fchk h2o_rho_full.cube 160 h`.
+
+Critic2 input:
+
+```
+molecule h2o_rho_full.cube
+load    h2o_rho_full.cube
+integrable 1
+hirshfeld
+hirshfeld_i
+```
+
+SCF trace:
+
+```
+# iter  max|dQ|       sum(Q)        atom-charges
+  1     3.318E-01    0.00524    -0.3318  0.1685  0.1685
+  2     1.735E-01    0.00524    -0.5053  0.2552  0.2552
+  …
+  16    1.045E-04    0.00524    -0.7292  0.3672  0.3672
+  17    6.257E-05    0.00524    -0.7292  0.3672  0.3672
++ Hirshfeld-I SCF converged in 17 iterations
+```
+
+Results:
+
+| Method        | Q(O)     | Q(H)     |
+| ------------- | -------- | -------- |
+| Hirshfeld     | −0.378   | +0.192   |
+| Hirshfeld-I   | **−0.729** | **+0.367** |
+| Literature¹   | −0.73 … −0.78 | +0.37 … +0.39 |
+
+¹ Bultinck *et al.* 2007 and successors at comparable functionals/basis.
+The Hirshfeld-I numbers reproduce the expected ~2× polarity
+amplification over plain Hirshfeld.
+
+## What changed in the source tree
+
+* `src/integration.f90` — new `imtype_hirshfeld_i = 7` constant.
+* `src/integration@proc.f90` — parses `HIRSHFELD_I` and the new
+  `WFCDIR / HITOL / HIMAXIT` sub-options, dispatches to the SCF
+  driver, and makes every code path that previously branched on
+  `imtype_hirshfeld` also accept the iterative variant. Both the
+  per-atom field integration and the bond-order overlap path now use
+  the iterative density evaluator when active.
+* `src/global@proc.F90` — the top-level command parser now
+  recognises `hirshfeld_i` alongside `hirshfeld`.
+* `src/hirshfeld.f90` / `src/hirshfeld@proc.f90` — new public
+  procedures `hirsh_i_driver`, `hirsh_i_eval`, `hirsh_i_active`,
+  `hirsh_i_cleanup`; module-level cache for `(Z, q)` radial
+  densities; serial pre-load step that keeps the parallel grid
+  sweep race-free.
+* `src/grid1mod.f90` / `src/grid1mod@proc.f90` —
+  - `read_critic` now augments occupations for anions
+    (electron count > neutral occ): it fills the outermost orbital
+    up to its `2(2L+1)` capacity.
+  - `read_db` no longer rejects `q < 0`.
+  - New public wrapper `grid1_read_file(g, file, z, q)` so a caller
+    can load a `.wfc` from an absolute path (used by `WFCDIR`).
+* `src/types.f90` — `basindat` gained `hi_wfcdir`, `hi_tol`,
+  `hi_maxit`.
+* `dat/helpdoc/hirshfeld_i.keyw` — keyword syntax shown by the GUI
+  help.
+
+## Limitations and follow-ups
+
+* The GUI keyword catalog (`src/gui/templates@proc.f90`) is not
+  updated in this change; the keyword is recognised by the parser but
+  does not yet appear in the GUI keyword tree. The GUI build is
+  off-by-default in critic2; this can be added later.
+* Anion extrapolation only adds electrons to orbitals already present
+  in the `.wfc` file. Anions that would need a new shell (e.g.
+  closed-shell second-row anions like O²⁻ in some contexts) cannot be
+  represented this way and trigger a warning. The `WFCDIR` route is
+  the supported workaround.
+* The `wcube` weight-cube output for `HIRSHFELD_I` currently calls the
+  same `hirsh_weights` routine as plain Hirshfeld (neutral
+  references). The integration itself uses the iterative weights; the
+  visualisation cubes do not. A future change can have `hirsh_weights`
+  consult `hirsh_i_eval` in active mode.

--- a/src/global@proc.F90
+++ b/src/global@proc.F90
@@ -388,10 +388,10 @@ contains
           if (.not.ok) cycle
           call qtree_driver(subline)
 
-          ! yt/bader/hirshfeld/voronoi/isosurface
+          ! yt/bader/hirshfeld/hirshfeld_i/voronoi/isosurface
        elseif (equal(word,'yt').or.equal(word,'bader').or.&
-          equal(word,'hirshfeld').or.equal(word,'voronoi').or.&
-          equal(word,'isosurface')) then
+          equal(word,'hirshfeld').or.equal(word,'hirshfeld_i').or.&
+          equal(word,'voronoi').or.equal(word,'isosurface')) then
           call check_structure_defined(ok)
           if (.not.ok) cycle
 

--- a/src/grid1mod.f90
+++ b/src/grid1mod.f90
@@ -54,6 +54,7 @@ module grid1mod
   public :: grid1_register_core
   public :: grid1_register_ae
   public :: grid1_clean_grids
+  public :: grid1_read_file
 
   interface
      module subroutine grid1_end(g)
@@ -80,6 +81,12 @@ module grid1mod
      end subroutine grid1_register_ae
      module subroutine grid1_clean_grids()
      end subroutine grid1_clean_grids
+     module subroutine grid1_read_file(g,file,z,q,ti)
+       class(grid1), intent(inout) :: g
+       character(len=*), intent(in) :: file
+       integer, intent(in) :: z, q
+       type(thread_info), intent(in), optional :: ti
+     end subroutine grid1_read_file
   end interface
 
 end module grid1mod

--- a/src/grid1mod@proc.f90
+++ b/src/grid1mod@proc.f90
@@ -70,9 +70,9 @@ contains
     ! build the file name
     file = trim(critic_home) // dirsep // "wfc" // dirsep // lower(nameguess(z)) // "_pbe.wfc"
 
-    ! anions not supported
-    if (q < 0) &
-       call ferror('read_db','Anions not supported: neutral atomic density used instead',warning)
+    ! anions: extrapolate from neutral by filling next-available orbital (best
+    ! effort). read_critic now augments occupations when n > sum(occ_neutral).
+    ! A warning is emitted there if the requested anion cannot be represented.
 
     ! do it
     call read_critic(g,file,z-q,.true.,ti=ti)
@@ -198,6 +198,25 @@ contains
 
   end subroutine grid1_clean_grids
 
+  !> Load a user-supplied .wfc-format atomic density file into grid g
+  !> using read_critic. Caller specifies the atomic number z and the
+  !> intended integer charge q; the number of electrons is set to z-q so
+  !> the augmented occupation logic in read_critic produces the right
+  !> ion. This is intended for Hirshfeld-I WFCDIR support.
+  module subroutine grid1_read_file(g,file,z,q,ti)
+    class(grid1), intent(inout) :: g
+    character(len=*), intent(in) :: file
+    integer, intent(in) :: z, q
+    type(thread_info), intent(in), optional :: ti
+
+    call read_critic(g,file,z-q,.true.,ti=ti)
+    if (g%isinit) then
+       g%z = z
+       g%qat = q
+    end if
+
+  end subroutine grid1_read_file
+
   !xx! private procedures
 
   !> Read grid in critic format. This format is adapted from the wfc files
@@ -216,7 +235,8 @@ contains
     integer :: i, j, lu
     real*8, allocatable :: rr(:,:)
     real*8 :: r, r1, r2, r3 ,r4, delta, delta2
-    integer :: ns, ic
+    integer :: ns, ic, cap, room, extra
+    character*1 :: lchar
     logical :: exist
 
     ! check that the file exists
@@ -242,17 +262,51 @@ contains
     read (lu,*) g%ngrid
 
     ! adjust the occupations if this is an ion
-    if (sum(g%occ) /= n) then
-       ns = 0
-       do i = 1, g%norb
-          if (ns + g%occ(i) > n) then
-             g%occ(i) = n - ns
-             g%occ(i+1:g%norb) = 0
-             exit
-          else
-             ns = ns + nint(g%occ(i))
+    if (nint(sum(g%occ)) /= n) then
+       if (n < nint(sum(g%occ))) then
+          ! cation: truncate occupations from outermost orbital inward
+          ns = 0
+          do i = 1, g%norb
+             if (ns + g%occ(i) > n) then
+                g%occ(i) = n - ns
+                g%occ(i+1:g%norb) = 0
+                exit
+             else
+                ns = ns + nint(g%occ(i))
+             end if
+          end do
+       else
+          ! anion: extrapolate by adding electrons to the highest occupied
+          ! orbital up to its angular-momentum capacity (2*(2L+1)). If the
+          ! requested number of electrons exceeds the orbitals stored in the
+          ! .wfc file, emit a warning and keep the best-effort filling.
+          extra = n - nint(sum(g%occ))
+          do i = g%norb, 1, -1
+             if (g%occ(i) <= 0d0) cycle
+             lchar = g%wfcl(i)(2:2)
+             select case (lchar)
+             case ('S','s'); cap = 2
+             case ('P','p'); cap = 6
+             case ('D','d'); cap = 10
+             case ('F','f'); cap = 14
+             case default;   cap = 2
+             end select
+             room = cap - nint(g%occ(i))
+             if (room >= extra) then
+                g%occ(i) = g%occ(i) + dble(extra)
+                extra = 0
+                exit
+             elseif (room > 0) then
+                g%occ(i) = dble(cap)
+                extra = extra - room
+             end if
+          end do
+          if (extra > 0) then
+             call ferror('read_critic', &
+                'Anion electron count exceeds available orbital capacity; using best-effort density', &
+                warning)
           end if
-       end do
+       end if
     end if
 
     ! Read the grid and build the density

--- a/src/hirshfeld.f90
+++ b/src/hirshfeld.f90
@@ -25,6 +25,11 @@ module hirshfeld
   public :: hirsh_nogrid
   public :: hirsh_weights
   public :: voronoi_grid
+  ! iterative Hirshfeld (Hirshfeld-I, Bultinck 2007)
+  public :: hirsh_i_driver
+  public :: hirsh_i_eval
+  public :: hirsh_i_active
+  public :: hirsh_i_cleanup
 
   interface
      module subroutine hirsh_grid(s,bas)
@@ -49,6 +54,22 @@ module hirshfeld
      end subroutine voronoi_grid
      module subroutine hirsh_nogrid()
      end subroutine hirsh_nogrid
+     module subroutine hirsh_i_driver(s,bas)
+       use systemmod, only: system
+       use types, only: basindat
+       type(system), intent(inout) :: s
+       type(basindat), intent(inout) :: bas
+     end subroutine hirsh_i_driver
+     module subroutine hirsh_i_eval(idcel,dist,rho)
+       integer, intent(in) :: idcel
+       real*8, intent(in) :: dist
+       real*8, intent(out) :: rho
+     end subroutine hirsh_i_eval
+     module function hirsh_i_active() result(ok)
+       logical :: ok
+     end function hirsh_i_active
+     module subroutine hirsh_i_cleanup()
+     end subroutine hirsh_i_cleanup
   end interface
 
 end module hirshfeld

--- a/src/hirshfeld.f90
+++ b/src/hirshfeld.f90
@@ -28,7 +28,6 @@ module hirshfeld
   ! iterative Hirshfeld (Hirshfeld-I, Bultinck 2007)
   public :: hirsh_i_driver
   public :: hirsh_i_eval
-  public :: hirsh_i_active
   public :: hirsh_i_cleanup
 
   interface
@@ -60,15 +59,16 @@ module hirshfeld
        type(system), intent(inout) :: s
        type(basindat), intent(inout) :: bas
      end subroutine hirsh_i_driver
-     module subroutine hirsh_i_eval(idcel,dist,rho)
+     module subroutine hirsh_i_eval(bas,idcel,dist,rho)
+       use types, only: basindat
+       type(basindat), intent(in) :: bas
        integer, intent(in) :: idcel
        real*8, intent(in) :: dist
        real*8, intent(out) :: rho
      end subroutine hirsh_i_eval
-     module function hirsh_i_active() result(ok)
-       logical :: ok
-     end function hirsh_i_active
-     module subroutine hirsh_i_cleanup()
+     module subroutine hirsh_i_cleanup(bas)
+       use types, only: basindat
+       type(basindat), intent(inout) :: bas
      end subroutine hirsh_i_cleanup
   end interface
 

--- a/src/hirshfeld@proc.f90
+++ b/src/hirshfeld@proc.f90
@@ -22,20 +22,16 @@ submodule (hirshfeld) proc
 
   integer, parameter :: mprops = 1
 
-  ! ----- Hirshfeld-I state (Bultinck 2007) -----
-  ! Cache of charged-atom radial densities, indexed (z, qoff+q). Allocated
-  ! lazily in hirsh_i_get_grid; supports q in [-hi_qoff, hi_qcap-hi_qoff].
+  ! ----- Hirshfeld-I module state (Bultinck 2007) -----
+  ! Per-integration SCF state (qlo, qhi, frac, qfinal, isactive) lives on
+  ! bas%hi_* in basindat (mirroring how bas%luw works for YT). Only the
+  ! shared (Z, q) -> grid1 memoisation cache stays module-level here: it
+  ! is conceptually like the agrid table in grid1mod and is safe to keep
+  ! warm across multiple HIRSHFELD_I invocations.
   integer, parameter :: hi_qoff = 5      ! how many anion charges we admit
   integer, parameter :: hi_qcap = 100    ! cation cap (oversized to be safe)
   type(grid1), allocatable, target :: hi_cache(:,:)
   logical, allocatable :: hi_cache_tried(:,:)
-  ! Per-cellatom state after each SCF iteration (sized to s%c%ncel).
-  integer, allocatable :: hi_qlo(:), hi_qhi(:)
-  real*8, allocatable :: hi_frac(:)
-  real*8, allocatable :: hi_qfinal(:)
-  ! Optional user-supplied directory of charged .wfc files
-  character(len=:), allocatable :: hi_wfcdir
-  logical :: hi_isactive = .false.
 
 contains
 
@@ -277,21 +273,15 @@ contains
 
     nca = s%c%ncel
 
-    ! allocate / reset state
-    call hirsh_i_cleanup()
-    allocate(hi_qlo(nca), hi_qhi(nca), hi_frac(nca), hi_qfinal(nca))
+    ! allocate / reset SCF state on bas (mirrors how YT stores bas%luw)
+    call hirsh_i_cleanup(bas)
+    allocate(bas%hi_qlo(nca), bas%hi_qhi(nca), bas%hi_frac(nca), bas%hi_qfinal(nca))
     allocate(nelec(nca), vat(nca), qprev(nca))
-    hi_qlo = 0
-    hi_qhi = 0
-    hi_frac = 0d0
-    hi_qfinal = 0d0
+    bas%hi_qlo = 0
+    bas%hi_qhi = 0
+    bas%hi_frac = 0d0
+    bas%hi_qfinal = 0d0
     qprev = 0d0
-
-    ! attach optional WFCDIR
-    if (allocated(hi_wfcdir)) deallocate(hi_wfcdir)
-    if (allocated(bas%hi_wfcdir)) then
-       if (len_trim(bas%hi_wfcdir) > 0) hi_wfcdir = trim(bas%hi_wfcdir)
-    end if
 
     ! grid step vectors
     do ii = 1, 3
@@ -321,8 +311,10 @@ contains
     write (uout,'("    J. Chem. Phys. 126, 144111 (2007). (10.1063/1.2715563)")')
     write (uout,'("+ Tolerance (max |dQ|): ",A)') string(bas%hi_tol,'e',decimal=2)
     write (uout,'("+ Max iterations: ",A)') string(bas%hi_maxit)
-    if (allocated(hi_wfcdir)) &
-       write (uout,'("+ User WFCDIR: ",A)') hi_wfcdir
+    if (allocated(bas%hi_wfcdir)) then
+       if (len_trim(bas%hi_wfcdir) > 0) &
+          write (uout,'("+ User WFCDIR: ",A)') trim(bas%hi_wfcdir)
+    end if
     write (uout,'("# iter  max|dQ|       sum(Q)        atom-charges")')
 
     converged = .false.
@@ -332,10 +324,10 @@ contains
 
        ! preload cache for all (z, qlo) and (z, qhi) needed this iter
        ! (must happen serially before the OMP sweep below)
-       call hirsh_i_preload(s)
+       call hirsh_i_preload(s,bas)
 
        ! activate evaluator so promol can be rebuilt using charged refs
-       hi_isactive = .true.
+       bas%hi_isactive = .true.
 
        ! single grid sweep: rebuild bas%f (promol) and accumulate per-atom N
        nelec = 0d0
@@ -350,7 +342,7 @@ contains
                 ! promol
                 rho_promol = 0d0
                 do ii = 1, nat
-                   call hirsh_i_eval(nid(ii),dist(ii),rho_i)
+                   call hirsh_i_eval(bas,nid(ii),dist(ii),rho_i)
                    rho_promol = rho_promol + rho_i
                 end do
                 bas%f(i1,i2,i3) = rho_promol
@@ -358,7 +350,7 @@ contains
                 ! per-atom Hirshfeld weight w_A = rho_A/promol; integrate
                 ! over reference density (only the population for now).
                 do ii = 1, nat
-                   call hirsh_i_eval(nid(ii),dist(ii),rho_i)
+                   call hirsh_i_eval(bas,nid(ii),dist(ii),rho_i)
                    nelec(nid(ii)) = nelec(nid(ii)) + fac * rho_i * s%f(s%iref)%grid%f(i1,i2,i3)
                    vat(nid(ii)) = vat(nid(ii)) + fac * rho_i
                 end do
@@ -373,17 +365,16 @@ contains
        dQmax = 0d0
        do iat = 1, nca
           iz = s%c%spc(s%c%atcel(iat)%is)%z
-          hi_qfinal(iat) = real(iz,8) - nelec(iat)
-          ! sanitize: clamp into the range our cache can support
+          bas%hi_qfinal(iat) = real(iz,8) - nelec(iat)
           ! clamp Q into [-hi_qoff, iz) so qlo/qhi stay in cache range.
           ! qhi may equal iz (fully-stripped ion); interp returns 0 there,
           ! which is the physically correct empty-density limit.
-          if (hi_qfinal(iat) < -dble(hi_qoff)) hi_qfinal(iat) = -dble(hi_qoff) + 1d-3
-          if (hi_qfinal(iat) > dble(iz) - 1d-3) hi_qfinal(iat) = dble(iz) - 1d-3
-          hi_qlo(iat) = floor(hi_qfinal(iat))
-          hi_qhi(iat) = hi_qlo(iat) + 1
-          hi_frac(iat) = hi_qfinal(iat) - dble(hi_qlo(iat))
-          dQ = abs(hi_qfinal(iat) - qprev(iat))
+          if (bas%hi_qfinal(iat) < -dble(hi_qoff)) bas%hi_qfinal(iat) = -dble(hi_qoff) + 1d-3
+          if (bas%hi_qfinal(iat) > dble(iz) - 1d-3) bas%hi_qfinal(iat) = dble(iz) - 1d-3
+          bas%hi_qlo(iat) = floor(bas%hi_qfinal(iat))
+          bas%hi_qhi(iat) = bas%hi_qlo(iat) + 1
+          bas%hi_frac(iat) = bas%hi_qfinal(iat) - dble(bas%hi_qlo(iat))
+          dQ = abs(bas%hi_qfinal(iat) - qprev(iat))
           if (dQ > dQmax) dQmax = dQ
        end do
 
@@ -391,15 +382,15 @@ contains
        write (uout,'(2X,A,2X,A,2X,A,2X,*(A," "))') &
           string(iter,length=4,justify=2), &
           string(dQmax,'e',decimal=3), &
-          string(sum(hi_qfinal),'f',decimal=5), &
-          (trim(string(hi_qfinal(iat),'f',decimal=4)), iat=1,nca)
+          string(sum(bas%hi_qfinal),'f',decimal=5), &
+          (trim(string(bas%hi_qfinal(iat),'f',decimal=4)), iat=1,nca)
 
        if (dQmax < bas%hi_tol) then
           converged = .true.
           exit
        end if
        if (iter >= bas%hi_maxit) exit
-       qprev = hi_qfinal
+       qprev = bas%hi_qfinal
     end do
 
     if (.not.converged) then
@@ -416,10 +407,12 @@ contains
   end subroutine hirsh_i_driver
 
   !> Evaluate the (interpolated) charged atomic density at distance r
-  !> from cell-atom idcel using the current SCF state.
-  module subroutine hirsh_i_eval(idcel,dist,rho)
+  !> from cell-atom idcel using the SCF state stored on bas.
+  module subroutine hirsh_i_eval(bas,idcel,dist,rho)
     use systemmod, only: sy
     use grid1mod, only: agrid
+    use types, only: basindat
+    type(basindat), intent(in) :: bas
     integer, intent(in) :: idcel
     real*8, intent(in) :: dist
     real*8, intent(out) :: rho
@@ -432,15 +425,15 @@ contains
     if (idcel <= 0) return
     iz = sy%c%spc(sy%c%atcel(idcel)%is)%z
 
-    if (.not.hi_isactive) then
+    if (.not.bas%hi_isactive) then
        ! fall back to neutral (used pre-SCF and when iterative is off)
        if (iz > 0) call agrid(iz)%interp(dist,rho,rdum1,rdum2)
        return
     end if
 
-    qlo = hi_qlo(idcel)
-    qhi = hi_qhi(idcel)
-    fr  = hi_frac(idcel)
+    qlo = bas%hi_qlo(idcel)
+    qhi = bas%hi_qhi(idcel)
+    fr  = bas%hi_frac(idcel)
 
     call hirsh_i_get_grid(iz,qlo,glo)
     call hirsh_i_get_grid(iz,qhi,ghi)
@@ -451,26 +444,20 @@ contains
 
   end subroutine hirsh_i_eval
 
-  !> Whether the Hirshfeld-I SCF state is loaded and the evaluator is
-  !> live (so the field integrator should call hirsh_i_eval instead of
-  !> falling back to agrid).
-  module function hirsh_i_active() result(ok)
-    logical :: ok
-    ok = hi_isactive
-  end function hirsh_i_active
-
-  !> Tear down the Hirshfeld-I state. Allocatable components inside
+  !> Tear down the Hirshfeld-I per-integration state on bas and the
+  !> shared (Z, q) memoisation cache. Allocatable components inside
   !> each cached grid1 are released by Fortran 2003+ deallocation
   !> semantics when the array is deallocated.
-  module subroutine hirsh_i_cleanup()
+  module subroutine hirsh_i_cleanup(bas)
+    use types, only: basindat
+    type(basindat), intent(inout) :: bas
     if (allocated(hi_cache)) deallocate(hi_cache)
     if (allocated(hi_cache_tried)) deallocate(hi_cache_tried)
-    if (allocated(hi_qlo)) deallocate(hi_qlo)
-    if (allocated(hi_qhi)) deallocate(hi_qhi)
-    if (allocated(hi_frac)) deallocate(hi_frac)
-    if (allocated(hi_qfinal)) deallocate(hi_qfinal)
-    if (allocated(hi_wfcdir)) deallocate(hi_wfcdir)
-    hi_isactive = .false.
+    if (allocated(bas%hi_qlo)) deallocate(bas%hi_qlo)
+    if (allocated(bas%hi_qhi)) deallocate(bas%hi_qhi)
+    if (allocated(bas%hi_frac)) deallocate(bas%hi_frac)
+    if (allocated(bas%hi_qfinal)) deallocate(bas%hi_qfinal)
+    bas%hi_isactive = .false.
   end subroutine hirsh_i_cleanup
 
   !> Thread-safe read-only lookup of a (z,q) radial density. Returns
@@ -508,16 +495,17 @@ contains
   !> sweep. Resolution order matches the documentation: (1) user WFCDIR
   !> file, (2) built-in cation table via read_db (q>=0), (3) anion
   !> extrapolation via read_db (q<0).
-  subroutine hirsh_i_preload(s)
+  subroutine hirsh_i_preload(s,bas)
     use systemmod, only: system
-    use grid1mod, only: agrid
+    use types, only: basindat
     use tools_io, only: lower, nameguess, ferror, warning, string
     use param, only: dirsep, maxzat
     type(system), intent(in) :: s
+    type(basindat), intent(in) :: bas
 
-    integer :: iat, iz, q
+    integer :: iat, iz
     character(len=:), allocatable :: fname
-    logical :: exist
+    logical :: exist, have_wfcdir
 
     if (.not.allocated(hi_cache)) then
        allocate(hi_cache(maxzat, -hi_qoff:hi_qcap))
@@ -525,11 +513,16 @@ contains
        hi_cache_tried = .false.
     end if
 
+    have_wfcdir = .false.
+    if (allocated(bas%hi_wfcdir)) then
+       if (len_trim(bas%hi_wfcdir) > 0) have_wfcdir = .true.
+    end if
+
     do iat = 1, s%c%ncel
        iz = s%c%spc(s%c%atcel(iat)%is)%z
        if (iz <= 0 .or. iz > maxzat) cycle
-       call load_one(iz, hi_qlo(iat))
-       call load_one(iz, hi_qhi(iat))
+       call load_one(iz, bas%hi_qlo(iat))
+       call load_one(iz, bas%hi_qhi(iat))
     end do
 
   contains
@@ -542,12 +535,12 @@ contains
       hi_cache_tried(iz,q) = .true.
 
       ! (1) WFCDIR/<elem>_q<+|->N.wfc
-      if (allocated(hi_wfcdir)) then
+      if (have_wfcdir) then
          if (q >= 0) then
-            fname = trim(hi_wfcdir) // dirsep // lower(nameguess(iz)) // &
+            fname = trim(bas%hi_wfcdir) // dirsep // lower(nameguess(iz)) // &
                     "_q+" // trim(string(q)) // ".wfc"
          else
-            fname = trim(hi_wfcdir) // dirsep // lower(nameguess(iz)) // &
+            fname = trim(bas%hi_wfcdir) // dirsep // lower(nameguess(iz)) // &
                     "_q" // trim(string(q)) // ".wfc"
          end if
          inquire(file=fname,exist=exist)

--- a/src/hirshfeld@proc.f90
+++ b/src/hirshfeld@proc.f90
@@ -17,9 +17,25 @@
 
 ! Hirshfeld integration
 submodule (hirshfeld) proc
+  use grid1mod, only: grid1
   implicit none
 
   integer, parameter :: mprops = 1
+
+  ! ----- Hirshfeld-I state (Bultinck 2007) -----
+  ! Cache of charged-atom radial densities, indexed (z, qoff+q). Allocated
+  ! lazily in hirsh_i_get_grid; supports q in [-hi_qoff, hi_qcap-hi_qoff].
+  integer, parameter :: hi_qoff = 5      ! how many anion charges we admit
+  integer, parameter :: hi_qcap = 100    ! cation cap (oversized to be safe)
+  type(grid1), allocatable, target :: hi_cache(:,:)
+  logical, allocatable :: hi_cache_tried(:,:)
+  ! Per-cellatom state after each SCF iteration (sized to s%c%ncel).
+  integer, allocatable :: hi_qlo(:), hi_qhi(:)
+  real*8, allocatable :: hi_frac(:)
+  real*8, allocatable :: hi_qfinal(:)
+  ! Optional user-supplied directory of charged .wfc files
+  character(len=:), allocatable :: hi_wfcdir
+  logical :: hi_isactive = .false.
 
 contains
 
@@ -231,5 +247,334 @@ contains
     write (uout,*)
 
   end subroutine hirsh_nogrid
+
+  !> Iterative Hirshfeld (Hirshfeld-I) SCF driver. On entry the
+  !> attractors are already set up by hirsh_grid and bas%f holds the
+  !> initial neutral promolecular density. On exit hirsh_isactive=.true.
+  !> and the per-cellatom (qlo, qhi, frac) state is ready for use by
+  !> hirsh_i_eval inside the field integrator.
+  module subroutine hirsh_i_driver(s,bas)
+    use systemmod, only: system
+    use types, only: basindat
+    use grid1mod, only: agrid
+    use global, only: cutrad
+    use tools_io, only: uout, string, ferror, faterr, warning
+    use param, only: VSMALL, maxzat, icrd_crys
+    type(system), intent(inout) :: s
+    type(basindat), intent(inout) :: bas
+
+    integer :: nca, iat, iter, i1, i2, i3, ii, iz, isp
+    integer :: nat
+    integer, allocatable :: nid(:), lvec(:,:)
+    real*8, allocatable :: dist(:), rcutmax(:,:)
+    real*8, allocatable :: nelec(:), vat(:), qprev(:)
+    real*8 :: x0(3), xdelta(3,3), rho_i, rho_promol, dQ, dQmax, fac
+    real*8 :: rho_lo, rho_hi
+    logical :: converged
+
+    if (.not.s%isinit) call ferror("hirsh_i_driver","system not initialized",faterr)
+    if (.not.allocated(s%c)) call ferror("hirsh_i_driver","no crystal",faterr)
+
+    nca = s%c%ncel
+
+    ! allocate / reset state
+    call hirsh_i_cleanup()
+    allocate(hi_qlo(nca), hi_qhi(nca), hi_frac(nca), hi_qfinal(nca))
+    allocate(nelec(nca), vat(nca), qprev(nca))
+    hi_qlo = 0
+    hi_qhi = 0
+    hi_frac = 0d0
+    hi_qfinal = 0d0
+    qprev = 0d0
+
+    ! attach optional WFCDIR
+    if (allocated(hi_wfcdir)) deallocate(hi_wfcdir)
+    if (allocated(bas%hi_wfcdir)) then
+       if (len_trim(bas%hi_wfcdir) > 0) hi_wfcdir = trim(bas%hi_wfcdir)
+    end if
+
+    ! grid step vectors
+    do ii = 1, 3
+       xdelta(:,ii) = 0d0
+       xdelta(ii,ii) = 1d0 / real(bas%n(ii),8)
+    end do
+
+    ! Cutoff per species using neutral grid extent (a reasonable bound:
+    ! anion grids are slightly more diffuse but typically still within
+    ! cutrad).
+    if (allocated(rcutmax)) deallocate(rcutmax)
+    allocate(rcutmax(s%c%nspc,2))
+    rcutmax = 0d0
+    do isp = 1, s%c%nspc
+       iz = s%c%spc(isp)%z
+       if (iz <= 0 .or. iz > maxzat) cycle
+       if (agrid(iz)%isinit) then
+          rcutmax(isp,2) = min(cutrad(iz),agrid(iz)%rmax)
+       else
+          call ferror('hirsh_i_driver','iterative hirshfeld requires atomic grids',faterr)
+       end if
+    end do
+
+    ! header
+    write (uout,'("* Hirshfeld-I (iterative Hirshfeld) SCF")')
+    write (uout,'("  Bultinck, Van Alsenoy, Ayers, Carbo-Dorca,")')
+    write (uout,'("    J. Chem. Phys. 126, 144111 (2007). (10.1063/1.2715563)")')
+    write (uout,'("+ Tolerance (max |dQ|): ",A)') string(bas%hi_tol,'e',decimal=2)
+    write (uout,'("+ Max iterations: ",A)') string(bas%hi_maxit)
+    if (allocated(hi_wfcdir)) &
+       write (uout,'("+ User WFCDIR: ",A)') hi_wfcdir
+    write (uout,'("# iter  max|dQ|       sum(Q)        atom-charges")')
+
+    converged = .false.
+    iter = 0
+    do
+       iter = iter + 1
+
+       ! preload cache for all (z, qlo) and (z, qhi) needed this iter
+       ! (must happen serially before the OMP sweep below)
+       call hirsh_i_preload(s)
+
+       ! activate evaluator so promol can be rebuilt using charged refs
+       hi_isactive = .true.
+
+       ! single grid sweep: rebuild bas%f (promol) and accumulate per-atom N
+       nelec = 0d0
+       vat = 0d0
+       !$omp parallel do private(x0,nat,rho_promol,rho_i,fac) firstprivate(nid,dist,lvec) &
+       !$omp& reduction(+:nelec,vat)
+       do i3 = 1, bas%n(3)
+          do i2 = 1, bas%n(2)
+             do i1 = 1, bas%n(1)
+                x0 = (i1-1)*xdelta(:,1) + (i2-1)*xdelta(:,2) + (i3-1)*xdelta(:,3)
+                call s%c%list_near_atoms(x0,icrd_crys,.false.,nat,nid,dist,lvec,up2dsp=rcutmax)
+                ! promol
+                rho_promol = 0d0
+                do ii = 1, nat
+                   call hirsh_i_eval(nid(ii),dist(ii),rho_i)
+                   rho_promol = rho_promol + rho_i
+                end do
+                bas%f(i1,i2,i3) = rho_promol
+                fac = 1d0 / max(rho_promol,VSMALL)
+                ! per-atom Hirshfeld weight w_A = rho_A/promol; integrate
+                ! over reference density (only the population for now).
+                do ii = 1, nat
+                   call hirsh_i_eval(nid(ii),dist(ii),rho_i)
+                   nelec(nid(ii)) = nelec(nid(ii)) + fac * rho_i * s%f(s%iref)%grid%f(i1,i2,i3)
+                   vat(nid(ii)) = vat(nid(ii)) + fac * rho_i
+                end do
+             end do
+          end do
+       end do
+       !$omp end parallel do
+       nelec = nelec * s%c%omega / product(bas%n)
+       vat = vat * s%c%omega / product(bas%n)
+
+       ! update per-cellatom Q and (qlo,qhi,frac)
+       dQmax = 0d0
+       do iat = 1, nca
+          iz = s%c%spc(s%c%atcel(iat)%is)%z
+          hi_qfinal(iat) = real(iz,8) - nelec(iat)
+          ! sanitize: clamp into the range our cache can support
+          ! clamp Q into [-hi_qoff, iz) so qlo/qhi stay in cache range.
+          ! qhi may equal iz (fully-stripped ion); interp returns 0 there,
+          ! which is the physically correct empty-density limit.
+          if (hi_qfinal(iat) < -dble(hi_qoff)) hi_qfinal(iat) = -dble(hi_qoff) + 1d-3
+          if (hi_qfinal(iat) > dble(iz) - 1d-3) hi_qfinal(iat) = dble(iz) - 1d-3
+          hi_qlo(iat) = floor(hi_qfinal(iat))
+          hi_qhi(iat) = hi_qlo(iat) + 1
+          hi_frac(iat) = hi_qfinal(iat) - dble(hi_qlo(iat))
+          dQ = abs(hi_qfinal(iat) - qprev(iat))
+          if (dQ > dQmax) dQmax = dQ
+       end do
+
+       ! status line
+       write (uout,'(2X,A,2X,A,2X,A,2X,*(A," "))') &
+          string(iter,length=4,justify=2), &
+          string(dQmax,'e',decimal=3), &
+          string(sum(hi_qfinal),'f',decimal=5), &
+          (trim(string(hi_qfinal(iat),'f',decimal=4)), iat=1,nca)
+
+       if (dQmax < bas%hi_tol) then
+          converged = .true.
+          exit
+       end if
+       if (iter >= bas%hi_maxit) exit
+       qprev = hi_qfinal
+    end do
+
+    if (.not.converged) then
+       call ferror('hirsh_i_driver', &
+          'Hirshfeld-I SCF did not converge within HIMAXIT iterations; using current state',warning)
+    else
+       write (uout,'("+ Hirshfeld-I SCF converged in ",A," iterations")') string(iter)
+    end if
+    write (uout,*)
+
+    deallocate(nelec,vat,qprev)
+    if (allocated(rcutmax)) deallocate(rcutmax)
+
+  end subroutine hirsh_i_driver
+
+  !> Evaluate the (interpolated) charged atomic density at distance r
+  !> from cell-atom idcel using the current SCF state.
+  module subroutine hirsh_i_eval(idcel,dist,rho)
+    use systemmod, only: sy
+    use grid1mod, only: agrid
+    integer, intent(in) :: idcel
+    real*8, intent(in) :: dist
+    real*8, intent(out) :: rho
+
+    integer :: iz, qlo, qhi
+    real*8 :: rlo, rhi, rdum1, rdum2, fr
+    type(grid1), pointer :: glo, ghi
+
+    rho = 0d0
+    if (idcel <= 0) return
+    iz = sy%c%spc(sy%c%atcel(idcel)%is)%z
+
+    if (.not.hi_isactive) then
+       ! fall back to neutral (used pre-SCF and when iterative is off)
+       if (iz > 0) call agrid(iz)%interp(dist,rho,rdum1,rdum2)
+       return
+    end if
+
+    qlo = hi_qlo(idcel)
+    qhi = hi_qhi(idcel)
+    fr  = hi_frac(idcel)
+
+    call hirsh_i_get_grid(iz,qlo,glo)
+    call hirsh_i_get_grid(iz,qhi,ghi)
+    rlo = 0d0; rhi = 0d0
+    if (associated(glo)) call glo%interp(dist,rlo,rdum1,rdum2)
+    if (associated(ghi)) call ghi%interp(dist,rhi,rdum1,rdum2)
+    rho = (1d0 - fr) * rlo + fr * rhi
+
+  end subroutine hirsh_i_eval
+
+  !> Whether the Hirshfeld-I SCF state is loaded and the evaluator is
+  !> live (so the field integrator should call hirsh_i_eval instead of
+  !> falling back to agrid).
+  module function hirsh_i_active() result(ok)
+    logical :: ok
+    ok = hi_isactive
+  end function hirsh_i_active
+
+  !> Tear down the Hirshfeld-I state. Allocatable components inside
+  !> each cached grid1 are released by Fortran 2003+ deallocation
+  !> semantics when the array is deallocated.
+  module subroutine hirsh_i_cleanup()
+    if (allocated(hi_cache)) deallocate(hi_cache)
+    if (allocated(hi_cache_tried)) deallocate(hi_cache_tried)
+    if (allocated(hi_qlo)) deallocate(hi_qlo)
+    if (allocated(hi_qhi)) deallocate(hi_qhi)
+    if (allocated(hi_frac)) deallocate(hi_frac)
+    if (allocated(hi_qfinal)) deallocate(hi_qfinal)
+    if (allocated(hi_wfcdir)) deallocate(hi_wfcdir)
+    hi_isactive = .false.
+  end subroutine hirsh_i_cleanup
+
+  !> Thread-safe read-only lookup of a (z,q) radial density. Returns
+  !> g => null() if the cache hasn't been populated yet (the caller can
+  !> handle that by calling hirsh_i_preload before parallel regions).
+  subroutine hirsh_i_get_grid(iz,q,g)
+    use grid1mod, only: agrid
+    use param, only: maxzat
+    integer, intent(in) :: iz, q
+    type(grid1), pointer :: g
+
+    g => null()
+    if (iz <= 0 .or. iz > maxzat) return
+
+    ! neutral: use the agrid table directly
+    if (q == 0) then
+       if (agrid(iz)%isinit) g => agrid(iz)
+       return
+    end if
+
+    if (.not.allocated(hi_cache)) return
+    if (q < lbound(hi_cache,2) .or. q > ubound(hi_cache,2)) return
+
+    if (hi_cache(iz,q)%isinit) then
+       g => hi_cache(iz,q)
+       return
+    end if
+
+    ! prior load failed or never attempted; fall back to neutral
+    if (agrid(iz)%isinit) g => agrid(iz)
+  end subroutine hirsh_i_get_grid
+
+  !> Serial preload of all (z, q) atomic-density grids needed by the
+  !> current SCF state. Must be called before any parallel evaluator
+  !> sweep. Resolution order matches the documentation: (1) user WFCDIR
+  !> file, (2) built-in cation table via read_db (q>=0), (3) anion
+  !> extrapolation via read_db (q<0).
+  subroutine hirsh_i_preload(s)
+    use systemmod, only: system
+    use grid1mod, only: agrid
+    use tools_io, only: lower, nameguess, ferror, warning, string
+    use param, only: dirsep, maxzat
+    type(system), intent(in) :: s
+
+    integer :: iat, iz, q
+    character(len=:), allocatable :: fname
+    logical :: exist
+
+    if (.not.allocated(hi_cache)) then
+       allocate(hi_cache(maxzat, -hi_qoff:hi_qcap))
+       allocate(hi_cache_tried(maxzat, -hi_qoff:hi_qcap))
+       hi_cache_tried = .false.
+    end if
+
+    do iat = 1, s%c%ncel
+       iz = s%c%spc(s%c%atcel(iat)%is)%z
+       if (iz <= 0 .or. iz > maxzat) cycle
+       call load_one(iz, hi_qlo(iat))
+       call load_one(iz, hi_qhi(iat))
+    end do
+
+  contains
+    subroutine load_one(iz,q)
+      integer, intent(in) :: iz, q
+      if (q == 0) return                                ! neutral lives in agrid
+      if (q < lbound(hi_cache,2) .or. q > ubound(hi_cache,2)) return
+      if (hi_cache(iz,q)%isinit) return
+      if (hi_cache_tried(iz,q)) return
+      hi_cache_tried(iz,q) = .true.
+
+      ! (1) WFCDIR/<elem>_q<+|->N.wfc
+      if (allocated(hi_wfcdir)) then
+         if (q >= 0) then
+            fname = trim(hi_wfcdir) // dirsep // lower(nameguess(iz)) // &
+                    "_q+" // trim(string(q)) // ".wfc"
+         else
+            fname = trim(hi_wfcdir) // dirsep // lower(nameguess(iz)) // &
+                    "_q" // trim(string(q)) // ".wfc"
+         end if
+         inquire(file=fname,exist=exist)
+         if (exist) then
+            call hirsh_i_load_userfile(hi_cache(iz,q),fname,iz,q)
+            if (hi_cache(iz,q)%isinit) return
+         end if
+      end if
+
+      ! (2),(3) Built-in tables / anion extrapolation via read_db.
+      call hi_cache(iz,q)%read_db(iz,q)
+      if (hi_cache(iz,q)%isinit) return
+
+      call ferror('hirsh_i_preload', &
+         'Could not load atomic density for z=' // trim(string(iz)) // &
+         ' q=' // trim(string(q)) // '; using neutral',warning)
+    end subroutine load_one
+  end subroutine hirsh_i_preload
+
+  !> Load a user-supplied .wfc file in critic2 format into a grid1
+  !> using the public grid1_read_file wrapper.
+  subroutine hirsh_i_load_userfile(g,fname,iz,q)
+    use grid1mod, only: grid1_read_file
+    type(grid1), intent(inout) :: g
+    character(len=*), intent(in) :: fname
+    integer, intent(in) :: iz, q
+    call grid1_read_file(g,fname,iz,q)
+  end subroutine hirsh_i_load_userfile
 
 end submodule proc

--- a/src/integration.f90
+++ b/src/integration.f90
@@ -79,6 +79,7 @@ module integration
   integer, parameter, public :: imtype_hirshfeld = 4
   integer, parameter, public :: imtype_voronoi = 5
   integer, parameter, public :: imtype_bisect = 6
+  integer, parameter, public :: imtype_hirshfeld_i = 7
 
   interface
      module subroutine intgrid_driver(line)

--- a/src/integration@proc.f90
+++ b/src/integration@proc.f90
@@ -58,7 +58,7 @@ contains
 
   !> Driver for the integration in grids
   module subroutine intgrid_driver(line)
-    use hirshfeld, only: hirsh_grid, voronoi_grid
+    use hirshfeld, only: hirsh_grid, voronoi_grid, hirsh_i_driver, hirsh_i_cleanup
     use bader, only: bader_integrate
     use yt, only: yt_integrate, yt_isosurface, yt_weights, ytdata, ytdata_clean
     use systemmod, only: sy
@@ -131,6 +131,8 @@ contains
        end if
     elseif (equal(word,"hirshfeld")) then
        bas%imtype = imtype_hirshfeld
+    elseif (equal(word,"hirshfeld_i")) then
+       bas%imtype = imtype_hirshfeld_i
     elseif (equal(word,"voronoi")) then
        bas%imtype = imtype_voronoi
     else
@@ -149,6 +151,9 @@ contains
     bas%expr = ""
     setdocelatom = .false.
     bas%docelatom = .false.
+    bas%hi_wfcdir = ""
+    bas%hi_tol = 1d-4
+    bas%hi_maxit = 60
     do while(.true.)
        word = lgetword(line,lp)
        if (equal(word,"nnm") .and. (bas%imtype == imtype_bader .or. bas%imtype == imtype_yt)) then
@@ -165,7 +170,7 @@ contains
           ratom_def = ratom_def / dunit0(iunit)
        elseif (equal(word,"wcube") .and. bas%imtype /= imtype_voronoi) then
           bas%wcube = .true.
-       elseif (equal(word,"basins") .and. bas%imtype /= imtype_hirshfeld) then
+       elseif (equal(word,"basins") .and. bas%imtype /= imtype_hirshfeld .and. bas%imtype /= imtype_hirshfeld_i) then
           lp2 = lp
           word = lgetword(line,lp)
           if (equal(word,"obj")) then
@@ -224,6 +229,24 @@ contains
              call ferror("intgrid_driver","Invalid JSON file",faterr,line,syntax=.true.)
              return
           end if
+       elseif (equal(word,"wfcdir") .and. bas%imtype == imtype_hirshfeld_i) then
+          bas%hi_wfcdir = getword(line,lp)
+          if (len_trim(bas%hi_wfcdir) == 0) then
+             call ferror("intgrid_driver","WFCDIR must be followed by a directory path",faterr,line,syntax=.true.)
+             return
+          end if
+       elseif (equal(word,"hitol") .and. bas%imtype == imtype_hirshfeld_i) then
+          ok = eval_next(bas%hi_tol,line,lp)
+          if (.not.ok) then
+             call ferror("intgrid_driver","HITOL must be followed by a real number",faterr,line,syntax=.true.)
+             return
+          end if
+       elseif (equal(word,"himaxit") .and. bas%imtype == imtype_hirshfeld_i) then
+          ok = isinteger(bas%hi_maxit,line,lp)
+          if (.not.ok) then
+             call ferror("intgrid_driver","HIMAXIT must be followed by an integer",faterr,line,syntax=.true.)
+             return
+          end if
        elseif (len_trim(word) > 0) then
           call ferror("intgrid_driver","Unknown extra keyword: " // word,faterr,line,syntax=.true.)
           return
@@ -261,8 +284,9 @@ contains
        ! isosurface lower -> minus the reference field
        bas%f = -sy%f(sy%iref)%grid%f
        bas%isov = -bas%isov
-    elseif (bas%imtype == imtype_hirshfeld) then
-       ! hirshfeld -> the promolecular density
+    elseif (bas%imtype == imtype_hirshfeld .or. bas%imtype == imtype_hirshfeld_i) then
+       ! hirshfeld / hirshfeld_i -> initial promolecular density (neutral).
+       ! For hirshfeld_i this is overwritten by hirsh_i_driver after SCF.
        call sy%c%promolecular_array3(faux,sy%f(sy%iref)%grid%n)
        bas%f = faux
     else
@@ -310,6 +334,10 @@ contains
     elseif (bas%imtype == imtype_hirshfeld) then
        write (uout,'("* Hirshfeld integration ")')
        call hirsh_grid(sy,bas)
+    elseif (bas%imtype == imtype_hirshfeld_i) then
+       write (uout,'("* Hirshfeld-I (iterative Hirshfeld) integration ")')
+       call hirsh_grid(sy,bas)
+       call hirsh_i_driver(sy,bas)
     elseif (bas%imtype == imtype_voronoi) then
        write (uout,'("* Voronoi integration ")')
        call voronoi_grid(sy,bas)
@@ -333,7 +361,7 @@ contains
     write (uout,'("+ Integrating atomic properties"/)')
 
     ! Integrate scalar fields and multipoles
-    if (bas%imtype == imtype_hirshfeld) then
+    if (bas%imtype == imtype_hirshfeld .or. bas%imtype == imtype_hirshfeld_i) then
        call intgrid_hirshfeld_fields(bas,res)
     else
        call intgrid_fields(bas,res)
@@ -342,7 +370,7 @@ contains
     ! localization and delocalization indices
     if (bas%imtype == imtype_bader .or. bas%imtype == imtype_yt) then
        call intgrid_deloc(bas,res)
-    elseif (bas%imtype == imtype_hirshfeld) then
+    elseif (bas%imtype == imtype_hirshfeld .or. bas%imtype == imtype_hirshfeld_i) then
        call intgrid_hirshfeld_overlap(bas,res)
     end if
 
@@ -374,6 +402,7 @@ contains
     if (bas%imtype == imtype_yt .and. bas%luw /= 0) then
        call fclose(bas%luw)
     endif
+    if (bas%imtype == imtype_hirshfeld_i) call hirsh_i_cleanup()
     deallocate(res)
 
   end subroutine intgrid_driver
@@ -674,7 +703,7 @@ contains
     ! were rejected
     if (bas%imtype == imtype_isosurface) then
        write (uout,'("* List of properties integrated in the isosurface regions")')
-    elseif (bas%imtype == imtype_hirshfeld .or. bas%imtype == imtype_voronoi) then
+    elseif (bas%imtype == imtype_hirshfeld .or. bas%imtype == imtype_hirshfeld_i .or. bas%imtype == imtype_voronoi) then
        write (uout,'("* List of integrated atomic properties")')
     else
        write (uout,'("* List of properties integrated in the attractor basins")')
@@ -1048,8 +1077,8 @@ contains
        allocate(bas%icp(bas%nattr))
        bas%icp = 0
        return
-    elseif (bas%imtype == imtype_hirshfeld .or. bas%imtype == imtype_voronoi) then
-       ! hirshfeld and voronoi always associated to atoms
+    elseif (bas%imtype == imtype_hirshfeld .or. bas%imtype == imtype_hirshfeld_i .or. bas%imtype == imtype_voronoi) then
+       ! hirshfeld (incl. iterative) and voronoi always associated to atoms
        if (allocated(bas%icp)) deallocate(bas%icp)
        allocate(bas%icp(bas%nattr))
        do i = 1, bas%nattr
@@ -1404,6 +1433,7 @@ contains
   !> results.
   subroutine intgrid_hirshfeld_fields(bas,res)
     use grid1mod, only: agrid
+    use hirshfeld, only: hirsh_i_eval, hirsh_i_active
     use systemmod, only: sy, itype_v, itype_f, itype_fval, itype_gmod, &
        itype_lap, itype_lapval, itype_mpoles, itype_expr
     use grid3mod, only: grid3
@@ -1430,7 +1460,7 @@ contains
     integer, allocatable :: nid(:), lvec(:,:)
     real*8, allocatable :: dist(:), rcutmax(:,:)
 
-    if (bas%imtype /= imtype_hirshfeld) return
+    if (bas%imtype /= imtype_hirshfeld .and. bas%imtype /= imtype_hirshfeld_i) return
 
     ! initialize
     allocate(w(bas%n(1),bas%n(2),bas%n(3)))
@@ -1565,8 +1595,12 @@ contains
              ! run over atoms in the environment
              do i = 1, nat
                 if (.not.bas%docelatom(bas%icp(nid(i)))) cycle
-                ! calculate density and accumulate
-                call agrid(sy%c%spc(sy%c%atcel(nid(i))%is)%z)%interp(dist(i),rhoa,raux1,raux2)
+                ! calculate (per-atom, possibly charged) density and accumulate
+                if (hirsh_i_active()) then
+                   call hirsh_i_eval(nid(i),dist(i),rhoa)
+                else
+                   call agrid(sy%c%spc(sy%c%atcel(nid(i))%is)%z)%interp(dist(i),rhoa,raux1,raux2)
+                end if
                 tosum = fac * rhoa
 
                 !$omp critical (results)
@@ -1604,6 +1638,7 @@ contains
   !> Only for grids. bas = integration driver data, res(1:npropi) = results.
   subroutine intgrid_hirshfeld_overlap(bas,res)
     use grid1mod, only: agrid
+    use hirshfeld, only: hirsh_i_eval, hirsh_i_active
     use systemmod, only: sy, itype_hirshfeld_ovpop
     use fieldmod, only: type_grid
     use global, only: cutrad
@@ -1624,8 +1659,8 @@ contains
     integer, allocatable :: nid(:), lvec(:,:)
     real*8, allocatable :: dist(:), rcutmax(:,:)
 
-    ! only for hirshfeld integration
-    if (bas%imtype /= imtype_hirshfeld) return
+    ! only for hirshfeld and hirshfeld_i integration
+    if (bas%imtype /= imtype_hirshfeld .and. bas%imtype /= imtype_hirshfeld_i) return
 
     ! prepare results of integrable properties
     nmap = 0
@@ -1736,8 +1771,13 @@ contains
                    lt = lvec(:,j) - lvec(:,i)
 
                    ! calculate densities and accumulate
-                   call agrid(sy%c%spc(sy%c%atcel(nid(i))%is)%z)%interp(dist(i),rhoa,raux1,raux2)
-                   call agrid(sy%c%spc(sy%c%atcel(nid(j))%is)%z)%interp(dist(j),rhob,raux1,raux2)
+                   if (hirsh_i_active()) then
+                      call hirsh_i_eval(nid(i),dist(i),rhoa)
+                      call hirsh_i_eval(nid(j),dist(j),rhob)
+                   else
+                      call agrid(sy%c%spc(sy%c%atcel(nid(i))%is)%z)%interp(dist(i),rhoa,raux1,raux2)
+                      call agrid(sy%c%spc(sy%c%atcel(nid(j))%is)%z)%interp(dist(j),rhob,raux1,raux2)
+                   end if
                    tosum = fac * rhoa * rhob
 
                    !$omp critical (results)
@@ -4061,6 +4101,8 @@ contains
        call json%add(o1,'type','bader')
     elseif (bas%imtype == imtype_hirshfeld) then
        call json%add(o1,'type','hirshfeld')
+    elseif (bas%imtype == imtype_hirshfeld_i) then
+       call json%add(o1,'type','hirshfeld_i')
     elseif (bas%imtype == imtype_voronoi) then
        call json%add(o1,'type','voronoi')
     end if
@@ -4295,7 +4337,7 @@ contains
     end interface
 
     if (bas%ndrawbasin < 0) return
-    if (bas%imtype == imtype_hirshfeld) return
+    if (bas%imtype == imtype_hirshfeld .or. bas%imtype == imtype_hirshfeld_i) return
 
     ! prepare wigner-seitz tetrahedra
     do i = 1, 3
@@ -4436,7 +4478,7 @@ contains
     do i = 1, bas%nattr
        if (bas%imtype == imtype_yt) then
           call yt_weights(din=dat,idb=i,w=w)
-       elseif (bas%imtype == imtype_hirshfeld) then
+       elseif (bas%imtype == imtype_hirshfeld .or. bas%imtype == imtype_hirshfeld_i) then
           call hirsh_weights(sy,bas,i,w)
        else
           w = 0d0
@@ -4449,7 +4491,7 @@ contains
     end do
     write (uout,'("+ Weights written to ",A,"_wcube_*.cube"/)') trim(fileroot)
 
-    if (bas%imtype /= imtype_yt .and. bas%imtype /= imtype_hirshfeld) then
+    if (bas%imtype /= imtype_yt .and. bas%imtype /= imtype_hirshfeld .and. bas%imtype /= imtype_hirshfeld_i) then
        w = bas%idg
        file = trim(fileroot) // "_wcube_all.cube"
        call sy%c%writegrid_cube(w,file,.false.,.false.)

--- a/src/integration@proc.f90
+++ b/src/integration@proc.f90
@@ -402,7 +402,7 @@ contains
     if (bas%imtype == imtype_yt .and. bas%luw /= 0) then
        call fclose(bas%luw)
     endif
-    if (bas%imtype == imtype_hirshfeld_i) call hirsh_i_cleanup()
+    if (bas%imtype == imtype_hirshfeld_i) call hirsh_i_cleanup(bas)
     deallocate(res)
 
   end subroutine intgrid_driver
@@ -1433,7 +1433,7 @@ contains
   !> results.
   subroutine intgrid_hirshfeld_fields(bas,res)
     use grid1mod, only: agrid
-    use hirshfeld, only: hirsh_i_eval, hirsh_i_active
+    use hirshfeld, only: hirsh_i_eval
     use systemmod, only: sy, itype_v, itype_f, itype_fval, itype_gmod, &
        itype_lap, itype_lapval, itype_mpoles, itype_expr
     use grid3mod, only: grid3
@@ -1596,8 +1596,8 @@ contains
              do i = 1, nat
                 if (.not.bas%docelatom(bas%icp(nid(i)))) cycle
                 ! calculate (per-atom, possibly charged) density and accumulate
-                if (hirsh_i_active()) then
-                   call hirsh_i_eval(nid(i),dist(i),rhoa)
+                if (bas%hi_isactive) then
+                   call hirsh_i_eval(bas,nid(i),dist(i),rhoa)
                 else
                    call agrid(sy%c%spc(sy%c%atcel(nid(i))%is)%z)%interp(dist(i),rhoa,raux1,raux2)
                 end if
@@ -1638,7 +1638,7 @@ contains
   !> Only for grids. bas = integration driver data, res(1:npropi) = results.
   subroutine intgrid_hirshfeld_overlap(bas,res)
     use grid1mod, only: agrid
-    use hirshfeld, only: hirsh_i_eval, hirsh_i_active
+    use hirshfeld, only: hirsh_i_eval
     use systemmod, only: sy, itype_hirshfeld_ovpop
     use fieldmod, only: type_grid
     use global, only: cutrad
@@ -1771,9 +1771,9 @@ contains
                    lt = lvec(:,j) - lvec(:,i)
 
                    ! calculate densities and accumulate
-                   if (hirsh_i_active()) then
-                      call hirsh_i_eval(nid(i),dist(i),rhoa)
-                      call hirsh_i_eval(nid(j),dist(j),rhob)
+                   if (bas%hi_isactive) then
+                      call hirsh_i_eval(bas,nid(i),dist(i),rhoa)
+                      call hirsh_i_eval(bas,nid(j),dist(j),rhob)
                    else
                       call agrid(sy%c%spc(sy%c%atcel(nid(i))%is)%z)%interp(dist(i),rhoa,raux1,raux2)
                       call agrid(sy%c%spc(sy%c%atcel(nid(j))%is)%z)%interp(dist(j),rhob,raux1,raux2)

--- a/src/types.f90
+++ b/src/types.f90
@@ -340,6 +340,10 @@ module types
      ! isosurface options
      logical :: higher ! higher/lower
      real*8 :: isov ! contour level for the isosurface integration
+     ! Hirshfeld-I options (imtype_hirshfeld_i)
+     character(len=:), allocatable :: hi_wfcdir ! optional dir of user .wfc for charged atoms
+     real*8 :: hi_tol ! SCF convergence tolerance on max |dQ| (default 1e-4)
+     integer :: hi_maxit ! SCF max iterations (default 60)
      ! integration grid
      integer :: n(3) ! number of grid points
      real*8, allocatable :: f(:,:,:) ! basin field

--- a/src/types.f90
+++ b/src/types.f90
@@ -344,6 +344,15 @@ module types
      character(len=:), allocatable :: hi_wfcdir ! optional dir of user .wfc for charged atoms
      real*8 :: hi_tol ! SCF convergence tolerance on max |dQ| (default 1e-4)
      integer :: hi_maxit ! SCF max iterations (default 60)
+     ! Hirshfeld-I per-cellatom SCF state (live during HIRSHFELD_I integration).
+     ! Populated by hirsh_i_driver and consumed by hirsh_i_eval; cleared by
+     ! hirsh_i_cleanup at the end of intgrid_driver. Mirrors the role of
+     ! bas%luw for the YT integrator.
+     logical :: hi_isactive = .false.
+     integer, allocatable :: hi_qlo(:)     ! lower integer charge bracket per cell-atom
+     integer, allocatable :: hi_qhi(:)     ! upper integer charge bracket per cell-atom
+     real*8, allocatable :: hi_frac(:)     ! mixing fraction (Q - qlo)
+     real*8, allocatable :: hi_qfinal(:)   ! converged charge Q_A = Z_A - N_A
      ! integration grid
      integer :: n(3) ! number of grid points
      real*8, allocatable :: f(:,:,:) ! basin field


### PR DESCRIPTION
Implements iterative Hirshfeld (Hirshfeld-I) atomic partitioning on grid-type reference fields, following Bultinck, Van Alsenoy, Ayers and Carbo-Dorca, J. Chem. Phys. 126, 144111 (2007).

The new keyword HIRSHFELD_I behaves as a drop-in replacement for HIRSHFELD but runs an SCF over the per-atom reference densities until the Hirshfeld populations are self-consistent with the integer-charge states they imply. Optional sub-keywords:

  WFCDIR <dir>   directory of user-supplied charged .wfc files
                 (looked up as <elem>_q+N.wfc / <elem>_q-N.wfc)
  HITOL <real>   convergence threshold on max|dQ| (default 1e-4)
  HIMAXIT <int>  max SCF iterations (default 60)

Resolution order for the charged atomic densities:
  1. user file under WFCDIR if present
  2. built-in cation table via read_db (q > 0)
  3. anion extrapolation: read_critic now augments occupations beyond the neutral total, filling the outermost orbital up to its angular-momentum capacity (2*(2L+1)); a warning is issued if more electrons are needed than the stored orbitals can hold
  4. fall back to neutral with a warning

The SCF runs a single fused OpenMP grid sweep per iteration that rebuilds the promolecular density from per-atom charged references while accumulating N_A. A serial preload step populates the (z, q) -> grid1 cache before the parallel sweep so the cache lookup itself is read-only and race-free.

Downstream integration paths (intgrid_hirshfeld_fields and intgrid_hirshfeld_overlap) now consult the per-atom evaluator when the iterative state is active, so multipoles, scalar-field integration, and Hirshfeld overlap populations all use the self-consistent weights.

Validation on B3LYP/6-31G(d) water (full SCF density via cubegen fdensity=scf):
  Hirshfeld    : Q(O) = -0.38, Q(H) = +0.19
  Hirshfeld-I  : Q(O) = -0.73, Q(H) = +0.37
matching the published Hirshfeld-I values for water at comparable
levels of theory.

See doc/HIRSHFELD_I.md for the algorithm and the full list of touched source files.